### PR TITLE
refactor whatsapp api way of sending polls

### DIFF
--- a/backend/controllers/poll.controller.js
+++ b/backend/controllers/poll.controller.js
@@ -1,7 +1,5 @@
 const pollServices = require('../services/poll.services');
 
-const dummyPhones = ['523333549944', '523333864523', '523317072870', '523315997504']
-
 exports.getAllPolls = (req, res, next) => {
     pollServices.index((err, polls) => {
         if (err){

--- a/backend/controllers/poll.controller.js
+++ b/backend/controllers/poll.controller.js
@@ -1,43 +1,4 @@
-const request = require('request');
 const pollServices = require('../services/poll.services');
-
-const dummyPolls = [
-    {
-        "name": "Poll 1",
-        "description": "This is the first poll",
-        "phoneNumbers": [
-            "1234567890",
-            "0987654321"
-        ],
-        "questions": [
-            {
-                "question": "What is your favorite color?",
-                "options": [
-                    "Red",
-                    "Blue",
-                ]
-            },
-        ]
-    },
-    {
-        "name": "Poll 2",
-        "description": "This is the first poll",
-        "phoneNumbers": [
-            "1234567890",
-            "0987654321"
-        ],
-        "questions": [
-            {
-                "question": "What is your favorite color?",
-                "options": [
-                    "Red",
-                    "Blue",
-                ]
-            },
-
-        ]
-    },
-];
 
 const dummyPhones = ['523333549944', '523333864523', '523317072870', '523315997504']
 
@@ -91,49 +52,7 @@ exports.deletePoll = (req, res, next) => {
 
 exports.testWhats = (req, res, next) => {
     for (let index = 0; index < dummyPhones.length; index++) {
-    const options = {
-        url: 'https://graph.facebook.com/v15.0/' + process.env.IdentificadorNumTel + '/messages',
-        headers: {
-            'Authorization': 'Bearer ' + process.env.Token,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(
-            {
-                "messaging_product": "whatsapp",
-                "recipient_type": "individual",
-                "to": dummyPhones[index],
-                "type": "interactive",
-                "interactive": {
-                    "type": "button",
-                    "body": {
-                        "text": dummyPolls[0].questions[0].question
-                    },
-                    "action": {
-                        "buttons": [
-                            {
-                                "type": "reply",
-                                "reply": {
-                                    "id": "UNIQUE_BUTTON_ID_1",
-                                    "title": dummyPolls[0].questions[0].options[0]
-                                }
-                            },
-                            {
-                                "type": "reply",
-                                "reply": {
-                                    "id": "UNIQUE_BUTTON_ID_2",
-                                    "title": dummyPolls[0].questions[0].options[1]
-                                }
-                            }
-                        ]
-                    }
 
-                }
-            })
-    };
-    request.post(options, (err, res2, body) => {
-        if (err) { return res.status(500).send("Pues no funciono la api") }
-        console.log(body);
-    });
     }
     res.status(200).json("Messages Sent");
 };

--- a/backend/controllers/whatsapp.controller.js
+++ b/backend/controllers/whatsapp.controller.js
@@ -1,0 +1,21 @@
+const whatsappServices = require('../services/whatsapp.services');
+
+exports.sendPollToAll = (req, res, next) => {
+
+    const { question, options, phoneNumbers } = req.body;
+
+    if (question === undefined || options === undefined || phoneNumbers === undefined) {
+        return next({
+            message: 'Question, Options, and Phone are required'
+        });
+    }
+
+    phoneNumbers.forEach((phone) => {
+        whatsappServices.transmit(question, options, phone, (error, results) => {
+            if (error) {
+                return next(error);
+            }
+            return res.status(200).json(results);
+        });
+    });
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -46,6 +46,7 @@ app.use(express.json());
 app.use('/users', require('./routes/users.routes'));
 app.use('/polls', require('./routes/polls.routes'));
 app.use('/people', require('./routes/people.routes'));
+app.use('/whatsapp', require('./routes/whatsapp.routes'));
 
 app.use(errors.errorHandler);
 

--- a/backend/routes/whatsapp.routes.js
+++ b/backend/routes/whatsapp.routes.js
@@ -1,0 +1,8 @@
+const whatsappController = require('../controllers/whatsapp.controller');
+
+const express = require('express');
+const router = express.Router();
+
+router.post('/send-poll-to-all', whatsappController.sendPollToAll);
+
+module.exports = router;

--- a/backend/services/whatsapp.services.js
+++ b/backend/services/whatsapp.services.js
@@ -1,0 +1,61 @@
+const request = require('request');
+
+function transmit(question, possibleAnswers, phone, callback) {
+
+    if (question === undefined || possibleAnswers === undefined || phone === undefined) {
+        return callback({
+            message: 'Question, Options, and Phone are required'
+        });
+    }
+
+    const url = 'https://graph.facebook.com/v15.0/' + process.env.IdentificadorNumTel + '/messages';
+
+    const headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + process.env.Token
+    };
+
+    const buttons = possibleAnswers.map((option, index) => {
+        return {
+            type: "reply",
+            "reply": {
+                "id": `UNIQUE_BUTTON_ID_${index}`,
+                "title": option
+            }
+        }
+    });
+
+    const body = {
+        "messaging_product": "whatsapp",
+        "recipient_type": "individual",
+        "to": phone,
+        "type": "interactive",
+        "interactive": {
+            "type": "button",
+            "body": {
+                "text": question
+            },
+            "action": {
+                "buttons": buttons
+            }
+
+        }
+    };
+
+    const options = {
+        url: url,
+        headers: headers,
+        body: JSON.stringify(body),
+    };
+
+    request.post(options, (err, res, body) => {
+        if (err) {
+            return callback(err);
+        }
+        return callback(null, body);
+    });
+}
+
+module.exports = {
+    transmit
+};


### PR DESCRIPTION
This PR contains the following changes:

- Added new whatsapp route `/whatsapp/send-poll-to-all`
- Created whatsapp service and controller to have a more scalable infrastructure